### PR TITLE
feat: add 0 score failing support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aga"
-version = "0.13.5"
+version = "0.13.6"
 description = "aga grades assignments"
 authors = ["Riley Shahar <riley.shahar@gmail.com>"]
 license = "MIT"

--- a/src/aga/gradescope/schema.py
+++ b/src/aga/gradescope/schema.py
@@ -12,6 +12,7 @@ from dataclasses_json import dataclass_json
 from ..runner import ProblemOutput, TcOutput
 
 
+# pylint: disable=R0902
 @dataclass_json
 @dataclass
 class GradescopeTestJson:

--- a/src/aga/gradescope/schema.py
+++ b/src/aga/gradescope/schema.py
@@ -5,7 +5,7 @@ complete rewrite.
 """
 
 from dataclasses import dataclass, field
-from typing import Optional, TextIO
+from typing import Literal, Optional, TextIO
 
 from dataclasses_json import dataclass_json
 
@@ -35,6 +35,7 @@ class GradescopeTestJson:
 
     score: Optional[float] = None
     max_score: Optional[float] = None
+    status: Optional[Literal["passed", "failed"]] = None
     name: Optional[str] = None
     number: Optional[float] = None
     output: Optional[str] = None
@@ -47,6 +48,7 @@ class GradescopeTestJson:
         return cls(
             score=output.score,
             max_score=output.max_score,
+            status=output.status,
             name=output.name,
             output=output.rich_output,
             visibility="hidden" if output.hidden else "visible",

--- a/src/aga/runner.py
+++ b/src/aga/runner.py
@@ -54,7 +54,7 @@ class TcOutput:
     score: float
     max_score: float
     name: str
-    status: None | Literal["passed", "failed"]
+    status: None | Literal["passed", "failed"] = None
     hidden: bool = False
     description: Optional[str] = None
     error_description: Optional[str] = None

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -5,4 +5,4 @@ from aga import __version__ as agaversion
 
 def test_version() -> None:
     """Test that the version is correct."""
-    assert agaversion == "0.13.5"
+    assert agaversion == "0.13.6"

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -61,6 +61,7 @@ def test_square_failure_output(
             score=0,
             max_score=20 / 3,
             name="Test on 4.",
+            status="failed",
             error_description="Your submission didn't give the output we expected. "
             "We checked it with 4 and got 0, but we expected 16.",
             hidden=False,
@@ -72,6 +73,7 @@ def test_square_failure_output(
             score=0,
             max_score=20 / 3,
             name="Test on 2.",
+            status="failed",
             error_description="Your submission didn't give the output we expected. "
             "We checked it with 2 and got 0, but we expected 4.",
             hidden=False,
@@ -83,6 +85,7 @@ def test_square_failure_output(
             score=0,
             max_score=20 / 3,
             name="Test on -2.",
+            status="failed",
             error_description="Your submission didn't give the output we expected. "
             "We checked it with -2 and got 0, but we expected 4.",
             hidden=True,
@@ -145,6 +148,7 @@ def test_hello_world_failure(
         TcOutput(
             score=0.0,
             max_score=20.0,
+            status="failed",
             name="Test on .",
             error_description=HELLO_WORLD_FAILURE_OUT,
             hidden=False,
@@ -249,6 +253,7 @@ def test_hello_name_incorrect(
         TcOutput(
             score=0.0,
             max_score=10.0,
+            status="failed",
             name="Test on 'world','me'.",
             error_description=HELLO_NAME_FAILURE_OUT_ME,
             hidden=False,
@@ -259,6 +264,7 @@ def test_hello_name_incorrect(
         TcOutput(
             score=0.0,
             max_score=10.0,
+            status="failed",
             name="Test on 'Alice','Bob'.",
             error_description=HELLO_NAME_FAILURE_OUT_ALICE,
             hidden=False,
@@ -543,6 +549,7 @@ def test_description_overriden(
         TcOutput(
             score=0,
             max_score=20 / 3,
+            status="failed",
             name="Test on 10.",
             description="This is a custom description.",
             error_description="True != False",


### PR DESCRIPTION
In the case where a test case contribute 0 score to the total score, the test case cannot fail successfully. This PR resolves this issue. In the following code, the overrided test case will fail. 

```python
from aga import problem, test_case


def test_check(tc, golden, actual):
    return tc.assertTrue(False)


@test_case(aga_override_test=test_check, aga_value=0, aga_weight=0)
@test_case(1, 2, aga_expect=3)
@problem()
def example(a, b):
    return a + b
```