### PR TITLE
Fix: loading context values from student submissions instead of answer files 

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -123,20 +123,20 @@ The `case` exposes `args` arguments and `kwargs` variables which are passed from
 The `case` also exposes `name` and `description` variables which are the name of the test case and the description of the test case. Changing those variables is equivalent to changing `aga_name` and `aga_description` but this means you can set it dynamically during the testing. 
 
 
-## Capture Environment Values 
+## Capture Context Values 
 
-Sometimes a piece of assignment file includes multiple classes, and even though only one class is eventually tested, the other parts of students' answers can be crucial. For example, consider the following file. You can specify in the `envs` argument of `problem` decorator to capture the `GasStation` class, and in the override check function, you can reference the `GasStation` class in the student's answer. 
+Sometimes a piece of assignment file includes multiple classes, and even though only one class is eventually tested, the other parts of students' answers can be crucial. For example, consider the following file. You can specify in the `ctx` argument of `problem` decorator to capture the `GasStation` class, and in the override check function, you can reference the `GasStation` class in the student's answer. 
 
 ```python
 from aga import problem, test_case
 
 def override_check(case, golden, student):
-    # use case.env.GasStation to reference student's GasStation class implementation
+    # use case.ctx.GasStation to reference student's GasStation class implementation
     ...
 
 
 @test_case(aga_override_check=override_check)
-@problem(envs=['GasStation'])
+@problem(ctx=['GasStation'])
 class Car:
     # uses gas station somewhere in the code
     ...
@@ -145,4 +145,4 @@ class GasStation:
     ...
 ```
 
-Essentially, `envs` argument takes in an iterable of strings, and aga will search the corresponding fields in the students' submitted module (file). 
+Essentially, `ctx` argument takes in an iterable of strings, and aga will search the corresponding fields in the students' submitted module (file). 

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -146,3 +146,5 @@ class GasStation:
 ```
 
 Essentially, `ctx` argument takes in an iterable of strings, and aga will search the corresponding fields in the students' submitted module (file). 
+
+Note that `ctx` is should not be modified during overriden check functions, since the changes will persist to all the following test cases, which might not be the intended behavior.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aga"
-version = "0.13.9"
+version = "0.13.10"
 description = "aga grades assignments"
 authors = ["Riley Shahar <riley.shahar@gmail.com>"]
 license = "MIT"

--- a/src/aga/config.py
+++ b/src/aga/config.py
@@ -23,6 +23,8 @@ def _default_value(path: list[str]) -> Any:
 
 def _from_default(path: list[str]) -> Any:
     """Given a path of config names, construct a field which inherits the default."""
+    # pylint: disable=invalid-field-call
+    # this is necessary for the default_factory
     return field(default_factory=lambda: _default_value(path))  # type: ignore
 
 

--- a/src/aga/core/context.py
+++ b/src/aga/core/context.py
@@ -14,8 +14,8 @@ class SubmissionContext(dict[str, Any]):
 
     def update_from_path(self, path: str) -> None:
         """Update environment values from a given module."""
-        # pylint: disable=import-outside-toplevel
-        # to avoid circular imports
+        # pylint: disable=import-outside-toplevel, cyclic-import
+        # to avoid circular imports, I place the import here
         from ..loader import load_symbol_from_path
 
         for symbol in self.keys():

--- a/src/aga/core/context.py
+++ b/src/aga/core/context.py
@@ -14,6 +14,8 @@ class SubmissionContext(dict[str, Any]):
 
     def update_from_path(self, path: str) -> None:
         """Update environment values from a given module."""
+        # pylint: disable=import-outside-toplevel
+        # to avoid circular imports
         from ..loader import load_symbol_from_path
 
         for symbol in self.keys():

--- a/src/aga/core/context.py
+++ b/src/aga/core/context.py
@@ -1,11 +1,10 @@
 """Environment value wrapper."""
 from __future__ import annotations
 
-import types
 from typing import Iterable, Any
 
 
-class Environment(dict[str, Any]):
+class SubmissionContext(dict[str, Any]):
     """Environment value wrapper."""
 
     def __init__(self, env_targets: Iterable[str]) -> None:
@@ -13,14 +12,12 @@ class Environment(dict[str, Any]):
         for target in env_targets:
             self[target] = None
 
-    def update_from_module(self, mod: types.ModuleType) -> None:
+    def update_from_path(self, path: str) -> None:
         """Update environment values from a given module."""
-        for value_name in self.keys():
-            if value_name not in vars(mod):
-                raise ValueError(
-                    f"The variable `{value_name} does not exist in the module {mod}"
-                )
-            self[value_name] = getattr(mod, value_name)
+        from ..loader import load_symbol_from_path
+
+        for symbol in self.keys():
+            self[symbol] = load_symbol_from_path(path, symbol)
 
     def __getattr__(self, item: str) -> Any:
         """Get the value of an environment variable."""

--- a/src/aga/core/parameter.py
+++ b/src/aga/core/parameter.py
@@ -208,6 +208,7 @@ class _TestParam(AgaKeywordContainer):
 
     pipeline: ClassVar[partial[_TestParam]]
 
+    # pylint: disable=too-many-arguments
     @overload
     def __init__(
         self,
@@ -383,7 +384,7 @@ class _TestParams:
     product: ClassVar[partial[_TestParams]]
     singular_params: ClassVar[partial[_TestParams]]
 
-    # pylint: disable=too-many-locals
+    # pylint: disable=too-many-locals, too-many-arguments
     @overload
     def __init__(
         self,

--- a/src/aga/core/problem.py
+++ b/src/aga/core/problem.py
@@ -1,7 +1,6 @@
 """Problem and utilities."""
 from __future__ import annotations
 
-from types import ModuleType
 from typing import (
     TYPE_CHECKING,
     Callable,

--- a/src/aga/core/suite.py
+++ b/src/aga/core/suite.py
@@ -9,7 +9,7 @@ from typing import Any, Callable, Dict, Generic, Iterable, Sequence, Tuple, Type
 from unittest import TestCase, TestSuite
 from unittest.mock import patch
 
-from aga.core.environment import Environment
+from aga.core.context import SubmissionContext
 
 from ..config import AgaConfig, AgaTestConfig
 from ..score import Prize, ScoredPrize, ScoreInfo, compute_scores
@@ -154,11 +154,11 @@ class _TestInputs(TestCase, Generic[Output]):
         self,
         aga_param: _TestParam,
         mock_input: bool,
-        env: Environment | None = None,
+        ctx: SubmissionContext | None = None,
     ) -> None:
         super().__init__()
         self._mock_input = mock_input
-        self.env = env
+        self.ctx = ctx
         self._param: _TestParam = aga_param
         self.score_info = ScoreInfo(
             self.aga_kwargs.weight, self.aga_kwargs.value, self.aga_kwargs.extra_credit

--- a/src/aga/loader.py
+++ b/src/aga/loader.py
@@ -48,6 +48,10 @@ class ContextMissing(InvalidSubmissionError):
     """The submission file does not contain the values required by the environment."""
 
 
+class AmbiguousContext(InvalidSubmissionError):
+    """The submission file contains multiple values for the same environment variable."""
+
+
 def _get_spec_from_path(path: str, name: str) -> ModuleSpec:
     """Get the spec of the module at path."""
     spec = importlib.util.spec_from_file_location(name, path)

--- a/src/aga/loader.py
+++ b/src/aga/loader.py
@@ -157,6 +157,10 @@ def _load_symbol_from_dir(path: str, symbol: str) -> Any:
     """Load a specific symbol from any of the source files in a directory."""
     matching_symbols = []
     for file in os.listdir(path):
+        # ignore the pycache folder to avoid duplicated symbols
+        if file == "__pycache__":
+            continue
+
         try:
             file_path = pathjoin(path, file)
             matching_symbols.append(load_symbol_from_path(file_path, symbol))
@@ -164,9 +168,9 @@ def _load_symbol_from_dir(path: str, symbol: str) -> Any:
             pass
 
     if len(matching_symbols) > 1:
-        raise TooManyMatchingSymbols
+        raise TooManyMatchingSymbols(f"Multiple matching symbols {symbol} found.")
     if len(matching_symbols) == 0:
-        raise NoMatchingSymbol
+        raise NoMatchingSymbol(f"No matching symbol {symbol} found.")
     return matching_symbols[0]
 
 

--- a/src/aga/loader.py
+++ b/src/aga/loader.py
@@ -49,7 +49,7 @@ class ContextMissing(InvalidSubmissionError):
 
 
 class AmbiguousContext(InvalidSubmissionError):
-    """The submission file contains multiple values for the same environment variable."""
+    """The submission files have  multiple values for the same environment variable."""
 
 
 def _get_spec_from_path(path: str, name: str) -> ModuleSpec:

--- a/src/aga/loader.py
+++ b/src/aga/loader.py
@@ -44,7 +44,7 @@ class MultipleScripts(InvalidSubmissionError):
     """Too many scripts were found."""
 
 
-class EnvironmentContextError(InvalidSubmissionError):
+class ContextMissing(InvalidSubmissionError):
     """The submission file does not contain the values required by the environment."""
 
 

--- a/src/aga/loader.py
+++ b/src/aga/loader.py
@@ -44,6 +44,10 @@ class MultipleScripts(InvalidSubmissionError):
     """Too many scripts were found."""
 
 
+class EnvironmentContextError(InvalidSubmissionError):
+    """The submission file does not contain the values required by the environment."""
+
+
 def _get_spec_from_path(path: str, name: str) -> ModuleSpec:
     """Get the spec of the module at path."""
     spec = importlib.util.spec_from_file_location(name, path)
@@ -132,11 +136,8 @@ def _load_from_module_by(
 
 def _load_problems_from_module(module: ModuleType) -> Iterable[Problem[Any, Any]]:
     """Return all problems in the module."""
-    yield from (
-        prob.update_env_from(module)
-        for prob in _load_from_module_by(
-            lambda i: isinstance(i, Problem), module  # type: ignore
-        )
+    yield from _load_from_module_by(
+        lambda i: isinstance(i, Problem), module  # type: ignore
     )
 
 

--- a/src/aga/runner.py
+++ b/src/aga/runner.py
@@ -23,6 +23,8 @@ from .loader import (
     TooManyMatchingSymbols,
     load_script_from_path,
     load_symbol_from_path,
+    _load_source_from_file,
+    EnvironmentContextError,
 )
 from .score import ScoredPrize
 from .util import limited_traceback
@@ -311,6 +313,12 @@ def load_and_run(
             tests=[],
             score=0.0,
         )
+
+    try:
+        submission_mod = _load_source_from_file(path)
+        problem.update_env_from(submission_mod)
+    except Exception as e:
+        raise EnvironmentContextError from e
 
     suite, prizes = problem.generate_test_suite(under_test, metadata)
     return _run(suite, prizes, metadata)

--- a/src/aga/runner.py
+++ b/src/aga/runner.py
@@ -282,8 +282,6 @@ def load_and_run(
     try:
         if not problem.is_script:
             under_test = load_symbol_from_path(path, problem.expected_symbol())
-            problem.submission_context.update_from_path(path)
-
         else:
             under_test = load_script_from_path(path)
     except SubmissionSyntaxError as err:
@@ -318,6 +316,11 @@ def load_and_run(
             tests=[],
             score=0.0,
         )
+
+    if not problem.is_script:
+        # If the submission is a module, we need to update the required context
+        # with the values from the submission.
+        problem.submission_context.update_from_path(path)
 
     suite, prizes = problem.generate_test_suite(under_test, metadata)
     return _run(suite, prizes, metadata)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -166,7 +166,7 @@ class Car:
 """,
     "test_no_context_values": """
 class Car:
-    def __init__(self, tank: GasTank):
+    def __init__(self, tank):
         self.tank = tank
 """,
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -165,6 +165,11 @@ class Car:
     def __init__(self, tank: GasTank):
         self.tank = tank
 """,
+    "test_no_context_values": """
+class Car:
+    def __init__(self, tank: GasTank):
+        self.tank = tank
+""",
 }
 
 

--- a/tests/test_gradescope/test_main.py
+++ b/tests/test_gradescope/test_main.py
@@ -12,6 +12,7 @@ from pytest_mock import MockerFixture
 from aga import problem as agaproblem
 from aga.core import Problem
 from aga.gradescope.main import gradescope_main
+from aga.loader import ContextMissing
 from aga.runner import TcOutput
 
 AnyProblem = Problem[Any, Any]
@@ -653,10 +654,11 @@ def test_loading_missing_context_from_submission(
     tmp_path: Path,
     example_metadata_file: str,
 ) -> None:
-    get_gs_json(
-        test_context_loading,
-        source_test_no_context_values,
-        mocker,
-        tmp_path,
-        example_metadata_file,
-    )
+    with pytest.raises(ContextMissing):
+        get_gs_json(
+            test_context_loading,
+            source_test_no_context_values,
+            mocker,
+            tmp_path,
+            example_metadata_file,
+        )

--- a/tests/test_gradescope/test_main.py
+++ b/tests/test_gradescope/test_main.py
@@ -628,3 +628,19 @@ def test_json_override_name(gs_json_bad_override_description: Any, target: str) 
             gs_json_bad_override_description["tests"],
         )
     )
+
+
+def test_loading_context_from_submission(
+    test_context_loading: AnyProblem,
+    source_test_context_loading: Any,
+    mocker: MockerFixture,
+    tmp_path: Path,
+    example_metadata_file: str,
+) -> None:
+    get_gs_json(
+        test_context_loading,
+        source_test_context_loading,
+        mocker,
+        tmp_path,
+        example_metadata_file,
+    )

--- a/tests/test_gradescope/test_main.py
+++ b/tests/test_gradescope/test_main.py
@@ -644,3 +644,19 @@ def test_loading_context_from_submission(
         tmp_path,
         example_metadata_file,
     )
+
+
+def test_loading_missing_context_from_submission(
+    test_context_loading: AnyProblem,
+    source_test_no_context_values: Any,
+    mocker: MockerFixture,
+    tmp_path: Path,
+    example_metadata_file: str,
+) -> None:
+    get_gs_json(
+        test_context_loading,
+        source_test_no_context_values,
+        mocker,
+        tmp_path,
+        example_metadata_file,
+    )

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -5,4 +5,4 @@ from aga import __version__ as agaversion
 
 def test_version() -> None:
     """Test that the version is correct."""
-    assert agaversion == "0.13.9"
+    assert agaversion == "0.13.10"


### PR DESCRIPTION
The PR contains fixes to loading context values. Instead of loading it from answers, it's now correctly loading from the student's submission files. 

It also contains testing and doc explaining the usages. 